### PR TITLE
fix(analyst): normalize buyer premium percent formats (#126)

### DIFF
--- a/workers/dfg-analyst/src/analysis.ts
+++ b/workers/dfg-analyst/src/analysis.ts
@@ -169,9 +169,13 @@ function computeBuyerPremium(
     return { amount: Math.round(bid * pct), method: "percent" };
   }
 
-  // Flat premium (rare)
+  // Numeric premium = percentage (not flat dollar)
+  // Normalize: >1 = whole-number pct (15 → 0.15), ≤1 = decimal (0.15)
+  // Fix for #126: 0.15 was incorrectly treated as $0.15 flat instead of 15%
   if (typeof buyerPremium === "number") {
-    return { amount: buyerPremium, method: "flat" };
+    const rate = buyerPremium > 1 ? buyerPremium / 100 : buyerPremium;
+    const premiumAmount = Math.round(bid * rate);
+    return { amount: premiumAmount, method: "percent" };
   }
 
   return { amount: 0, method: "none" };


### PR DESCRIPTION
## Summary

Fixes bug where numeric `buyer_premium` values were treated as flat dollar amounts instead of percentages.

**Before:** `$1,000 bid × 0.15 buyer_premium` → **$0.15 premium** 💀
**After:** `$1,000 bid × 0.15 buyer_premium` → **$150 premium** ✓

## Root Cause

`analysis.ts:computeBuyerPremium()` line 173 returned numeric values as-is:
```typescript
// OLD (wrong)
if (typeof buyerPremium === "number") {
  return { amount: buyerPremium, method: "flat" };  // 0.15 → $0.15
}
```

## Fix

Normalize numeric values as percentages with defensive handling for both formats:
```typescript
// NEW (correct)
if (typeof buyerPremium === "number") {
  // If > 1: whole-number pct (15 → 0.15)
  // If ≤ 1: decimal pct (0.15 = 15%)
  const rate = buyerPremium > 1 ? buyerPremium / 100 : buyerPremium;
  const premiumAmount = Math.round(bid * rate);
  return { amount: premiumAmount, method: "percent" };
}
```

## Test Results

```
✓ Sierra tier: $1,700 bid → $299 premium
✓ Sierra injection: $1,700 bid → $299 premium
✅ Existing Sierra tier tests passed

✓ #126 Decimal format: 0.15 on $1,000 bid → $150 premium (expected $150)
✓ #126 Whole-number format: 15 on $1,000 bid → $150 premium (expected $150)
✓ #126 Edge case: 0.12 on $5,000 bid → $600 premium (expected $600)
✅ All buyer premium semantic tests passed (issue #126)
```

## Test plan

- [x] `npm run test` passes
- [x] `npx tsc --noEmit` passes
- [ ] QA: Test with IronPlanet or other non-Sierra listings

## Notes

- Independent of #140 (Sierra tier fix) — can merge in any order
- Affects non-Sierra sources that use simple percentage premiums

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)