### PR TITLE
fix(dfg-analyst): use acquisition cost as margin denominator (#127)

### DIFF
--- a/workers/dfg-analyst/src/analysis.ts
+++ b/workers/dfg-analyst/src/analysis.ts
@@ -480,14 +480,16 @@ export function calculateMaxBidBySearch(params: {
     const totalInvestment = assertFiniteNumber("totalInvestment", (acq as any).total_acquisition + rt);
 
     const profit = mr - totalInvestment;
-    const margin = mr > 0 ? profit / mr : 0;
+    // FIX #127: Margin = profit / acquisitionCost (NOT sale price)
+    const margin = totalInvestment > 0 ? profit / totalInvestment : 0;
 
     if (profit < reqProfit || margin < reqMargin) continue;
 
     if (hasDownsideConstraint) {
       const qs = quickSalePrice as number;
       const quickProfit = qs - totalInvestment;
-      const quickMargin = qs > 0 ? quickProfit / qs : 0;
+      // FIX #127: Margin = profit / acquisitionCost (NOT sale price)
+      const quickMargin = totalInvestment > 0 ? quickProfit / totalInvestment : 0;
 
       const downsideOk = quickProfit >= minQuickProfit || quickMargin >= minQuickMargin;
       if (!downsideOk) continue;

--- a/workers/dfg-analyst/src/calculation-spine.ts
+++ b/workers/dfg-analyst/src/calculation-spine.ts
@@ -138,14 +138,16 @@ export function buildCalculationSpine(args: {
   const totalAllIn = subtotalAcquisition + transport + repairs + otherFees;
 
   // Profits and margins
+  // FIX #127: Margin = profit / acquisitionCost (NOT sale price)
+  // This measures ROI on capital invested, per DFG doctrine
   const quickSaleProfit = marketPrices.quick_sale - totalAllIn;
-  const quickSaleMargin = marketPrices.quick_sale > 0 ? quickSaleProfit / marketPrices.quick_sale : 0;
+  const quickSaleMargin = totalAllIn > 0 ? quickSaleProfit / totalAllIn : 0;
 
   const expectedProfit = marketPrices.market_rate - totalAllIn;
-  const expectedMargin = marketPrices.market_rate > 0 ? expectedProfit / marketPrices.market_rate : 0;
+  const expectedMargin = totalAllIn > 0 ? expectedProfit / totalAllIn : 0;
 
   const premiumProfit = marketPrices.premium - totalAllIn;
-  const premiumMargin = marketPrices.premium > 0 ? premiumProfit / marketPrices.premium : 0;
+  const premiumMargin = totalAllIn > 0 ? premiumProfit / totalAllIn : 0;
 
   return {
     bid_amount: bidAmount,


### PR DESCRIPTION
## Summary

- Margin was calculated as `profit / salePrice` instead of `profit / acquisitionCost`
- Fixed 5 margin calculations:
  - `calculation-spine.ts`: `quick_sale_margin`, `expected_margin`, `premium_margin`
  - `analysis.ts`: `margin` and `quickMargin` in `calculateMaxBidBySearch`
- Added unit tests verifying the formula

## Acceptance Criteria

Per canonical money-math doctrine:
- **margin = profit / acquisitionCost (NOT sale price)**
- Example: $1,000 acquisition, $1,200 sale, $200 profit → **20% margin** (not 16.7%)

## Test Results

```
✓ #127: $545 profit on $1455 acquisition → 37.5% margin
  (Wrong formula would give 27.3%)
✓ #127: All margins use acquisition cost denominator
  Quick=12%, Expected=40%, Premium=86%
✅ All margin denominator tests passed (issue #127)
```

## Test plan

- [x] `npm run test` passes in dfg-analyst
- [x] `npx tsc --noEmit` type-check passes
- [ ] QA: Verify margin displays in UI are investment-based

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)