### PR TITLE
fix(analyst): correct margin formula in all calculations (#159)

### DIFF
--- a/workers/dfg-analyst/src/analysis.ts
+++ b/workers/dfg-analyst/src/analysis.ts
@@ -275,19 +275,19 @@ export function calculateProfitScenarios(
     quick_sale: {
       sale_price: qs,
       gross_profit: qs > 0 ? qs - ti : -ti,
-      margin: qs > 0 ? (qs - ti) / qs : 0,
+      margin: ti > 0 ? (qs - ti) / ti : 0,  // FIX #159: margin = profit / acquisition (not sale)
       days_to_sell: 7
     },
     expected: {
       sale_price: mr,
       gross_profit: mr > 0 ? mr - ti : -ti,
-      margin: mr > 0 ? (mr - ti) / mr : 0,
+      margin: ti > 0 ? (mr - ti) / ti : 0,  // FIX #159: margin = profit / acquisition (not sale)
       days_to_sell: holdingDays
     },
     premium: {
       sale_price: pr,
       gross_profit: pr > 0 ? pr - ti : -ti,
-      margin: pr > 0 ? (pr - ti) / pr : 0,
+      margin: ti > 0 ? (pr - ti) / ti : 0,  // FIX #159: margin = profit / acquisition (not sale)
       days_to_sell: 30
     }
   };
@@ -405,7 +405,8 @@ export function calculateMaxBid(
   targetMargin: number = 0.35
 ): number {
   const profitBasedMax = marketRate - repairTotal - targetProfit;
-  const marginBasedMax = Math.round(marketRate * (1 - targetMargin) - repairTotal);
+  // FIX #159: margin = profit / acquisition, so acquisition = sale / (1 + margin)
+  const marginBasedMax = Math.round(marketRate / (1 + targetMargin) - repairTotal);
   return Math.floor(Math.min(profitBasedMax, marginBasedMax) / 50) * 50;
 }
 
@@ -417,7 +418,8 @@ export function calculateMaxBidAllIn(
   targetMargin: number = 0.35
 ): number {
   const profitBased = (marketRate - repairTotal - targetProfit) / allInMultiplier;
-  const marginBased = (marketRate * (1 - targetMargin) - repairTotal) / allInMultiplier;
+  // FIX #159: margin = profit / acquisition, so acquisition = sale / (1 + margin)
+  const marginBased = (marketRate / (1 + targetMargin) - repairTotal) / allInMultiplier;
   return Math.floor(Math.min(profitBased, marginBased) / 50) * 50;
 }
 


### PR DESCRIPTION
Fixes #159

## CRITICAL P0 FIX

**Problem:** Multiple margin calculation bugs affecting EVERY analysis.

Sprint N+7 (#127) fixed `calculation-spine.ts` but missed `analysis.ts` - separate code paths creating inconsistent margins across the system.

---

## Bugs Fixed

### 1. buildProfitScenarios() - All Three Scenarios

**File:** `analysis.ts:278, 284, 290`

**Before (WRONG):**
```typescript
quick_sale: {
  margin: qs > 0 ? (qs - ti) / qs : 0,  // ❌ profit / sale
}
expected: {
  margin: mr > 0 ? (mr - ti) / mr : 0,  // ❌ profit / sale
}
premium: {
  margin: pr > 0 ? (pr - ti) / pr : 0,  // ❌ profit / sale
}
```

**After (CORRECT):**
```typescript
quick_sale: {
  margin: ti > 0 ? (qs - ti) / ti : 0,  // ✅ profit / acquisition
}
expected: {
  margin: ti > 0 ? (mr - ti) / ti : 0,  // ✅ profit / acquisition
}
premium: {
  margin: ti > 0 ? (pr - ti) / ti : 0,  // ✅ profit / acquisition
}
```

---

### 2. calculateMaxBid() - Margin-Based Max

**File:** `analysis.ts:408`

**Before (WRONG):**
```typescript
const marginBasedMax = Math.round(marketRate * (1 - targetMargin) - repairTotal);
// Uses: margin = profit / sale (inverted relationship)
```

**After (CORRECT):**
```typescript
const marginBasedMax = Math.round(marketRate / (1 + targetMargin) - repairTotal);
// Uses: margin = profit / acquisition
// Derivation: acquisition = sale / (1 + margin)
```

---

### 3. calculateMaxBidAllIn() - Margin-Based Max

**File:** `analysis.ts:420`

**Before (WRONG):**
```typescript
const marginBased = (marketRate * (1 - targetMargin) - repairTotal) / allInMultiplier;
```

**After (CORRECT):**
```typescript
const marginBased = (marketRate / (1 + targetMargin) - repairTotal) / allInMultiplier;
```

---

## Impact Examples

### Profit Scenario Margins

**Scenario:** $1000 acquisition, $1500 sale, $500 profit

**Before (WRONG):**
- Margin = $500 / $1500 = **33.3%**
- Verdict: "BUY" (meets 35% threshold? No!)
- Gate trigger: Yes (below 35%)

**After (CORRECT):**
- Margin = $500 / $1000 = **50%**
- Verdict: "STRONG_BUY" (exceeds 40% threshold)
- Gate trigger: No (well above 35%)

**Result:** Wrong verdicts, wrong gates, misleading operator guidance.

---

### Max Bid Calculation

**Scenario:** 35% target margin, $2000 sale, $200 repairs

**Before (WRONG):**
- Max bid = $2000 × 0.65 - $200 = **$1100**
- Operator walks away too early

**After (CORRECT):**
- Max bid = $2000 / 1.35 - $200 = **$1282**
- Operator can bid $182 higher

**Error:** $182 difference (14% wrong)

---

## Audit Results

**✅ CORRECT (Already fixed in #127):**
- `calculation-spine.ts:144,147,150` - All margins use `profit / totalAllIn` ✅

**❌ BROKEN (Fixed in this PR):**
- `analysis.ts:278,284,290` - buildProfitScenarios() ✅ FIXED
- `analysis.ts:408,420` - calculateMaxBid() functions ✅ FIXED

---

## Canonical Definition

From `CLAUDE.md` and `@dfg/money-math`:

```
Margin % = (Profit / Acquisition Cost) × 100
```

**NOT:** `Margin % = (Profit / Sale Price) × 100` ❌

---

## Testing

**Type Check:** ✅ Passing (`npx tsc --noEmit`)

**Existing Tests:** All acquisition tests in `acquisition.test.ts` still pass

**Impact Verification:**
- Scenarios now show higher margins (correct ROI)
- Max bids now higher when margin-constrained
- Gates evaluated against correct margins

---

## Changes Summary

**1 file changed, 5 lines fixed:**
- 3 margin calculations in buildProfitScenarios()
- 2 margin-based max bid formulas

**Zero breaking changes** - only fixes wrong calculations to match canonical definition.

---

## Related Issues

- #127 - Original margin denominator fix (calculation-spine.ts)
- #159 - This issue (extends fix to analysis.ts)
- #160 - "All-In Cost" messaging (P2, separate issue)

---

**Priority:** P0 (blocks all analysis credibility)  
**Status:** Ready for immediate merge + deploy  
**Risk:** Low (fixes calculations to match documented standard)