### PR TITLE
feat(app): remove Score vanity metric from UI [#153]

### DIFF
--- a/apps/dfg-app/src/app/opportunities/[id]/page.tsx
+++ b/apps/dfg-app/src/app/opportunities/[id]/page.tsx
@@ -418,10 +418,6 @@ export default function OpportunityDetailPage() {
                   {formatSourceLabel(opportunity.source)}
                 </span>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-500">Score:</span>
-                <ScoreBadge score={opportunity.buy_box_score} />
-              </div>
             </CardContent>
           </Card>
 

--- a/apps/dfg-app/src/components/OpportunityCard.tsx
+++ b/apps/dfg-app/src/components/OpportunityCard.tsx
@@ -61,21 +61,6 @@ export function OpportunityCard({ opportunity, selected, onSelect }: Opportunity
     >
       <CardContent className={cn('p-0', scoreTint)}>
         <div className="flex">
-          {/* Score indicator - vertical bar with large score */}
-          <div className={cn(
-            'flex flex-col items-center justify-center w-14 shrink-0 py-2',
-            isHighScore
-              ? 'bg-green-500 text-white'
-              : opportunity.buy_box_score >= 40
-                ? 'bg-amber-400 text-gray-900'
-                : 'bg-gray-300 text-gray-700 dark:bg-gray-600 dark:text-gray-300'
-          )}>
-            <span className="text-lg font-bold">{opportunity.buy_box_score}</span>
-            <span className="text-[10px] font-medium uppercase tracking-wide opacity-80">
-              {isHighScore ? 'Hot' : opportunity.buy_box_score >= 40 ? 'Fair' : 'Low'}
-            </span>
-          </div>
-
           {/* Image - smaller, as thumbnail only */}
           <div className="relative w-16 h-16 flex-shrink-0 bg-gray-100 dark:bg-gray-700 m-2 rounded overflow-hidden">
             {opportunity.primary_image_url ? (

--- a/apps/dfg-app/src/components/features/attention-required-list.tsx
+++ b/apps/dfg-app/src/components/features/attention-required-list.tsx
@@ -179,23 +179,6 @@ function AttentionItemRow({ item, rank, onTouch, onChipClick, onAction, pendingA
                   ${item.current_bid.toLocaleString()}
                 </span>
               )}
-              {/* Buy box score indicator (#69) */}
-              {item.buy_box_score != null && item.buy_box_score > 0 && (
-                <span
-                  className={cn(
-                    'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
-                    item.buy_box_score >= 70
-                      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                      : item.buy_box_score >= 40
-                        ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-                        : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-                  )}
-                  title={`Buy Box Score: ${item.buy_box_score}`}
-                >
-                  <TrendingUp className="h-3 w-3" />
-                  {item.buy_box_score}
-                </span>
-              )}
               {timeRemaining && (
                 <span className="text-xs text-gray-500 dark:text-gray-400">
                   {timeRemaining}


### PR DESCRIPTION
## Summary

Removes Score display from all operator-facing views. Verdict is now the only decision metric.

## Problem

- "Score: 85" creates cognitive dissonance with PASS verdict
- Operators second-guess PASS verdicts because "85 sounds good"
- Score is noise that undermines trust in Verdict

## Changes

- Removed score badge from OpportunityCard (list view)
- Removed "Score: 85" from opportunity detail page
- Removed score indicator from attention required list

## Impact

- Verdict (BUY / WATCH / PASS) is now most prominent
- No numeric scores visible to operators
- Cleaner, less confusing UI

**Note:** Score remains in backend/Analyst output for debugging, just not rendered to operators.

## Testing

- [x] Typecheck passes
- [x] Build succeeds
- [x] Lint warnings only (pre-existing image optimization warnings)

## AC

- [x] Score display removed from all views
- [x] Verdict is most prominent decision metric
- [x] No numeric scores visible to operators

Closes #153