### PR TITLE
FIX #53/#54/#57: Add missing ai_analysis_json column

### DIFF
--- a/workers/dfg-api/migrations/0007_add_ai_analysis_json.sql
+++ b/workers/dfg-api/migrations/0007_add_ai_analysis_json.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- DFG API Migration 007: Add ai_analysis_json column to analysis_runs
+-- =============================================================================
+-- Fixes #53/#54/#57: Add missing column for storing full AI analysis result
+-- =============================================================================
+
+ALTER TABLE analysis_runs ADD COLUMN ai_analysis_json TEXT;
+
+-- Add index for querying opportunities with AI analysis
+CREATE INDEX IF NOT EXISTS idx_analysis_runs_has_ai ON analysis_runs(opportunity_id)
+  WHERE ai_analysis_json IS NOT NULL;


### PR DESCRIPTION
## Summary
Fixes analysis persistence issues by adding the missing `ai_analysis_json` column to the `analysis_runs` table.

## Root Cause
The code in `opportunities.ts` was trying to INSERT into `ai_analysis_json` column (line 1548) that didn't exist in the database schema. This caused analysis data to fail to persist, resulting in "Needs Re-analysis" showing even after analysis ran.

## Changes
### Migration 0007
- ✅ Add `ai_analysis_json TEXT` column to `analysis_runs` table
- ✅ Add index for efficient querying of opportunities with AI analysis

### How It Works (No Code Changes Needed)
The existing code already implements the correct flow:
1. **Save**: `analyzeOpportunity()` inserts full AI result into `ai_analysis_json` (line 1563)
2. **Load**: `getOpportunity()` loads persisted AI analysis from database (line 503)
3. **Display**: Detail page receives `aiAnalysis` from API and displays it
4. **Refresh**: Page refresh fetches from DB, no data loss

## Test Plan
1. **Run migration**
   ```bash
   cd workers/dfg-api
   npm run db:migrate
   ```

2. **Trigger analysis on an opportunity**
   - Click "Analyze" button in detail page
   - Verify analysis appears in UI

3. **Refresh page**
   - Expected: Analysis still shows (loaded from DB)
   - Before fix: "Needs Re-analysis" badge appears

4. **Check database directly**
   ```sql
   SELECT id, ai_analysis_json FROM analysis_runs
   WHERE ai_analysis_json IS NOT NULL LIMIT 1;
   ```
   - Expected: JSON blob with investor_lens, buyer_lens, condition, etc.

## Acceptance Criteria
- [x] Clicking Analyze persists AI result to DB
- [x] Page refresh shows stored analysis  
- [x] Re-analyze updates record with new analysis
- [x] No analysis data lost on refresh
- [x] Migration added and tested

Closes #53, #54, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)