### PR TITLE
feat: surface enterprise rules, remove stale dfg-relay refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,7 @@ dfg/
 ├── workers/
 │   ├── dfg-api/          # Cloudflare Worker - REST API for opportunities
 │   ├── dfg-scout/        # Cloudflare Worker - auction scraping/pipeline
-│   ├── dfg-analyst/      # Cloudflare Worker - AI analysis engine
-│   └── dfg-relay/        # Cloudflare Worker - GitHub issue integration
+│   └── dfg-analyst/      # Cloudflare Worker - AI analysis engine
 ├── packages/             # Shared packages (currently minimal)
 ├── docs/                 # Documentation and specs
 └── AGENTS.md            # This file - Codex review guidelines
@@ -38,7 +37,7 @@ npm run type-check   # TypeScript check
 npm run lint         # ESLint
 
 # Workers (each worker directory)
-cd workers/dfg-api   # or dfg-scout, dfg-analyst, dfg-relay
+cd workers/dfg-api   # or dfg-scout, dfg-analyst
 npx tsc --noEmit     # TypeScript check
 npx wrangler dev     # Local dev server
 npx wrangler deploy  # Deploy to Cloudflare
@@ -157,7 +156,7 @@ npm run lint 2>&1 | head -50
 npm run build 2>&1 | tail -20
 
 # Workers (run for each)
-for worker in dfg-api dfg-scout dfg-analyst dfg-relay; do
+for worker in dfg-api dfg-scout dfg-analyst; do
   echo "=== $worker ==="
   cd workers/$worker
   npx tsc --noEmit 2>&1 | head -20


### PR DESCRIPTION
## Summary

- Add Enterprise Rules section with 6 critical guardrails
- Replace stale slash commands section with MCP-based session start
- Remove all dfg-relay references from CLAUDE.md and AGENTS.md (decommissioned 2026-02-13)
- Remove duplicate QA Grade Labels (covered by instruction modules reference)
- Add Instruction Modules table for on-demand VCMS doc fetching

Part of a cross-venture initiative to surface VCMS enterprise rules directly in agent instruction files.

## Test plan

- [ ] Verify no dfg-relay references remain in CLAUDE.md or AGENTS.md
- [ ] Verify Enterprise Rules section visible
- [ ] Verify session start uses MCP tools
- [ ] Verify QA Grade Labels removed (covered by team-workflow.md module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)