### PR TITLE
feat: add typecheck and tests to verify script and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cd ../../packages/dfg-types && npm install && npx tsup src/index.ts --format cjs,esm --dts
 
       - name: Type check
-        run: npm run type-check
+        run: npm run typecheck
 
       - name: Build
         run: npm run build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   verify:
-    name: Typecheck, Lint, Format
+    name: Typecheck, Lint, Format, Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,14 +17,20 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
-      - name: Install root dependencies
-        run: npm ci --ignore-scripts
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Format check
         run: npm run format:check
 
       - name: Lint
         run: npm run lint
+
+      - name: Test
+        run: npm test

--- a/apps/dfg-app/package.json
+++ b/apps/dfg-app/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dfg/types": "*",

--- a/apps/dfg-core/package.json
+++ b/apps/dfg-core/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start -p 3001",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "verify": "npm run format:check && npm run lint",
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
+    "verify": "npm run typecheck && npm run format:check && npm run lint && npm run test",
     "prepare": "husky || true"
   },
   "devDependencies": {

--- a/workers/dfg-analyst/package.json
+++ b/workers/dfg-analyst/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
     "test": "npx tsx src/__tests__/acquisition.test.ts",
     "test:full": "npx tsx test-carson.ts"
   },

--- a/workers/dfg-analyst/tsconfig.json
+++ b/workers/dfg-analyst/tsconfig.json
@@ -11,7 +11,10 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "@dfg/money-math": ["../../packages/dfg-money-math/src/index.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/workers/dfg-api/package.json
+++ b/workers/dfg-api/package.json
@@ -10,6 +10,7 @@
     "tail:production": "wrangler tail --env production",
     "db:migrate": "wrangler d1 execute dfg-scout-db --remote --file=migrations/001-opportunities.sql",
     "db:migrate:local": "wrangler d1 execute dfg-scout-db --local --file=migrations/001-opportunities.sql",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/workers/dfg-scout/package.json
+++ b/workers/dfg-scout/package.json
@@ -6,6 +6,7 @@
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev --test-scheduled",
 		"start": "wrangler dev --test-scheduled",
+		"typecheck": "tsc --noEmit",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},


### PR DESCRIPTION
## Summary
- Add root `typecheck` and `test` scripts delegating to workspaces via `--workspaces --if-present`
- Standardize script name from `type-check` to `typecheck` in apps/dfg-app and apps/dfg-core
- Add `typecheck` scripts to worker packages (dfg-api, dfg-scout, dfg-analyst)
- Add tsconfig paths configuration for `@dfg/money-math` in dfg-analyst to resolve module imports
- Update `verify` script to full pipeline: typecheck + format:check + lint + test
- Update CI verify workflow to include typecheck and test steps, bump to Node 22

## Test plan
- [x] `npm run verify` passes locally
- [x] Each workspace typecheck runs independently
- [x] All workspace tests pass via root `npm test`
- [x] CI workflow updated with all verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)