### PR TITLE
feat(dfg): adopt crane-test-harness for migration + D1 testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2950,6 +2950,19 @@
         "win32"
       ]
     },
+    "node_modules/@venturecrane/crane-test-harness": {
+      "version": "0.1.0",
+      "resolved": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+      "integrity": "sha512-TZNAZPD5n8UUcWYlIKjLulV7KKQDuyflZmsPIgTxI5PBvXPH0cguEbXnxIhxs/546/0vEXBRheLa5A+h5DcMRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -10843,6 +10856,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
+        "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
         "typescript": "^5.7.2",
         "vitest": "^4.0.18",
         "wrangler": "^4.69.0"
@@ -11539,6 +11553,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251209.0",
+        "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16",
         "wrangler": "^4.69.0"

--- a/workers/dfg-api/package.json
+++ b/workers/dfg-api/package.json
@@ -11,11 +11,12 @@
     "db:migrate": "wrangler d1 execute dfg-scout-db --remote --file=migrations/001-opportunities.sql",
     "db:migrate:local": "wrangler d1 execute dfg-scout-db --local --file=migrations/001-opportunities.sql",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --project unit --project harness",
     "test:watch": "vitest"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
+    "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
     "typescript": "^5.7.2",
     "vitest": "^4.0.18",
     "wrangler": "^4.69.0"

--- a/workers/dfg-api/test/harness/migrations.test.ts
+++ b/workers/dfg-api/test/harness/migrations.test.ts
@@ -1,0 +1,72 @@
+/**
+ * dfg-api migration validation via @venturecrane/crane-test-harness.
+ *
+ * Ensures the numbered migrations in workers/dfg-api/migrations/ apply
+ * cleanly to a fresh in-memory D1 shim and produce the schema the
+ * worker handlers depend on.
+ *
+ * Notes:
+ *  - dfg-api has no base schema.sql; all tables are created by the
+ *    numbered migrations (0001 onward).
+ *  - A macOS Finder duplicate "0005_standardize_sierra_source 2.sql"
+ *    exists alongside the canonical 0005 file. Applying both would
+ *    conflict, so the discovery pattern excludes filenames with a
+ *    space (i.e. requires `0001_name.sql` shape).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, '..', '..', 'migrations')
+
+// Strict pattern: 4-digit prefix, underscore, no spaces in name.
+const MIGRATION_PATTERN = /^\d{4}_[A-Za-z0-9_]+\.sql$/
+
+describe('dfg-api migrations via harness', () => {
+  it('discovers migrations in numeric order with no duplicates', () => {
+    const files = discoverNumericMigrations(migrationsDir, { pattern: MIGRATION_PATTERN })
+    const names = files.map((f) => f.split('/').pop()!)
+
+    // Numbers must be strictly increasing.
+    const numbers = names.map((n) => Number(n.slice(0, 4)))
+    for (let i = 1; i < numbers.length; i++) {
+      expect(numbers[i]).toBeGreaterThan(numbers[i - 1]!)
+    }
+
+    // The Finder duplicate "0005_standardize_sierra_source 2.sql" must be
+    // excluded so 0005 is not applied twice.
+    expect(names).not.toContain('0005_standardize_sierra_source 2.sql')
+    expect(names).toContain('0005_standardize_sierra_source.sql')
+  })
+
+  it('applies the full migration chain to a fresh DB', async () => {
+    const db = createTestD1()
+    const files = discoverNumericMigrations(migrationsDir, { pattern: MIGRATION_PATTERN })
+    await runMigrations(db, { files })
+
+    const result = await db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all<{ name: string }>()
+    const tables = result.results.map((r) => r.name)
+
+    // Tables the dfg-api worker source reads from or writes to.
+    const expected = [
+      'sources', // 0001
+      'opportunities', // 0001
+      'operator_actions', // 0001
+      'tuning_events', // 0001
+      'analysis_runs', // 0003
+      'mvc_events', // 0006
+    ]
+    for (const t of expected) {
+      expect(tables, `expected table ${t} to exist post-migration`).toContain(t)
+    }
+  })
+})

--- a/workers/dfg-api/vitest.config.ts
+++ b/workers/dfg-api/vitest.config.ts
@@ -4,5 +4,24 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          globals: true,
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+          exclude: ['test/harness/**'],
+        },
+      },
+      {
+        test: {
+          name: 'harness',
+          globals: true,
+          environment: 'node',
+          include: ['test/harness/**/*.test.ts'],
+        },
+      },
+    ],
   },
 })

--- a/workers/dfg-scout/package.json
+++ b/workers/dfg-scout/package.json
@@ -7,7 +7,7 @@
 		"dev": "wrangler dev --test-scheduled",
 		"start": "wrangler dev --test-scheduled",
 		"typecheck": "tsc --noEmit",
-		"test": "vitest run",
+		"test": "vitest run --project unit --project harness",
 		"test:watch": "vitest"
 	},
 	"dependencies": {
@@ -15,6 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20251209.0",
+		"@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
 		"typescript": "^5.9.3",
 		"vitest": "^4.0.16",
 		"wrangler": "^4.69.0"

--- a/workers/dfg-scout/test/harness/migrations.test.ts
+++ b/workers/dfg-scout/test/harness/migrations.test.ts
@@ -1,0 +1,70 @@
+/**
+ * dfg-scout migration validation via @venturecrane/crane-test-harness.
+ *
+ * Asserts that schema.sql + numbered migrations apply cleanly and
+ * produce the schema dfg-scout handlers depend on.
+ *
+ * Notes:
+ *  - dfg-scout's `schema.sql` is the consolidated current-state schema and
+ *    already reflects every column/table added by the numbered historical
+ *    migrations (001-008). Applying schema.sql AND the numbered files to a
+ *    fresh DB fails with "duplicate column name" because the numbered files
+ *    are one-time migrations for environments bootstrapped pre-schema.
+ *    For fresh-DB validation we therefore apply schema.sql alone, matching
+ *    how a brand new environment is provisioned.
+ *  - discoverNumericMigrations is still exercised against a custom 3-digit
+ *    dash pattern so the ordering contract is covered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	createTestD1,
+	runMigrations,
+	discoverNumericMigrations,
+} from '@venturecrane/crane-test-harness';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, '..', '..', 'migrations');
+
+// 3-digit prefix, dash, name, .sql. Excludes seed/reset/utility files.
+const MIGRATION_PATTERN = /^\d{3}-[A-Za-z0-9-]+\.sql$/;
+
+describe('dfg-scout migrations via harness', () => {
+	it('discovers schema.sql first then numbered migrations in order', () => {
+		const files = discoverNumericMigrations(migrationsDir, { pattern: MIGRATION_PATTERN });
+		expect(files[0]).toMatch(/schema\.sql$/);
+
+		const numbered = files.slice(1).map((f) => f.split('/').pop()!);
+		const numbers = numbered.map((n) => Number(n.slice(0, 3)));
+		for (let i = 1; i < numbers.length; i++) {
+			expect(numbers[i]).toBeGreaterThan(numbers[i - 1]!);
+		}
+		expect(numbers[0]).toBe(1);
+	});
+
+	it('applies schema.sql to a fresh DB and produces handler tables', async () => {
+		const db = createTestD1();
+		const files = discoverNumericMigrations(migrationsDir, { pattern: MIGRATION_PATTERN });
+		const schemaOnly = files.filter((f) => f.endsWith('schema.sql'));
+		expect(schemaOnly).toHaveLength(1);
+		await runMigrations(db, { files: schemaOnly });
+
+		const result = await db
+			.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+			.all<{ name: string }>();
+		const tables = result.results.map((r) => r.name);
+
+		// Tables the dfg-scout worker source reads from or writes to.
+		const expected = [
+			'listings', // schema.sql
+			'scout_runs', // schema.sql
+			'analyses', // 005
+			'category_defs', // schema.sql / 007
+		];
+		for (const t of expected) {
+			expect(tables, `expected table ${t} to exist post-migration`).toContain(t);
+		}
+	});
+});

--- a/workers/dfg-scout/vitest.config.ts
+++ b/workers/dfg-scout/vitest.config.ts
@@ -4,7 +4,26 @@ export default defineConfig({
 	test: {
 		environment: 'node',
 		globals: true,
-		include: ['src/**/*.test.ts'],
 		clearMocks: true,
+		projects: [
+			{
+				test: {
+					name: 'unit',
+					environment: 'node',
+					globals: true,
+					clearMocks: true,
+					include: ['src/**/*.test.ts'],
+					exclude: ['test/harness/**'],
+				},
+			},
+			{
+				test: {
+					name: 'harness',
+					environment: 'node',
+					globals: true,
+					include: ['test/harness/**/*.test.ts'],
+				},
+			},
+		],
 	},
 });


### PR DESCRIPTION
## Summary

PR 5/5 of the @venturecrane/crane-test-harness rollout. Adopts the harness in the two D1-backed workers in dfg-console and adds in-process migration tests.

## Workers adopted

- **workers/dfg-api** (D1-backed)
  - Devdep on `@venturecrane/crane-test-harness` via tarball URL
  - `vitest.config.ts` gains `unit` + `harness` projects
  - `test/harness/migrations.test.ts` applies 0001-0007 to a fresh `createTestD1()` and asserts these handler-used tables exist: **sources, opportunities, operator_actions, tuning_events, analysis_runs, mvc_events**
  - Custom strict pattern `^\d{4}_[A-Za-z0-9_]+\.sql$` excludes the macOS Finder duplicate `0005_standardize_sierra_source 2.sql` that would otherwise apply 0005 twice

- **workers/dfg-scout** (D1-backed)
  - Devdep + harness project + migration test
  - Asserts **listings, scout_runs, analyses, category_defs** exist after applying `schema.sql`
  - The numbered `001-008` files are one-time historical migrations whose `ALTER TABLE ADD COLUMN` statements collide with the consolidated `schema.sql` on a fresh DB, so the fresh-DB test applies `schema.sql` alone — which matches how a brand-new environment is actually provisioned. `discoverNumericMigrations` is still exercised with a custom 3-digit dash pattern to lock in ordering

- **workers/dfg-analyst**: skipped — no `d1_databases` binding in `wrangler.toml`. The self-contained `dfg-analyst-preview` sub-workspace is untouched.

## Test results (local)

- `dfg-api`: 41 tests passed (unit + harness)
- `dfg-scout`: 31 tests passed (unit + harness)

## Harness release

https://github.com/venturecrane/crane-console/releases/tag/crane-test-harness-v0.1.0

## Test plan

- [ ] CI green on `dfg-api` and `dfg-scout` vitest runs
- [ ] `npm run typecheck` passes for the two modified workers (pre-existing dfg-app serwist typecheck failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)