### PR TITLE
chore: align docs/ with documentation standard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+---
+title: Documentation
+sidebar:
+  order: 0
+---
+
+Documentation root for the Durgan Field Guide (DFG) venture repo.
+
+## Directories
+
+| Directory                | Description                                                   |
+| ------------------------ | ------------------------------------------------------------- |
+| [handoffs/](./handoffs/) | Per-team session handoff records (DEV, PM, QA)                |
+| [pm/](./pm/)             | Product requirements and multi-round PRD review contributions |
+| [process/](./process/)   | Project instructions, architecture reference, and workflows   |
+
+## Files
+
+| File                                             | Description                                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------------------- |
+| [worktrees-analysis.md](./worktrees-analysis.md) | Analysis of Git worktrees for parallel development (issue #172, 2026-01-07) |
+
+## Notes
+
+- `worktrees-analysis.md` sits at the docs root rather than in a subdirectory.
+  It is a one-off analysis artifact and does not belong to a canonical
+  directory. Leave in place.

--- a/docs/handoffs/index.md
+++ b/docs/handoffs/index.md
@@ -1,0 +1,18 @@
+---
+title: Handoffs
+sidebar:
+  order: 0
+---
+
+Per-team session handoff records for the Durgan Field Guide project. Each file
+is owned by one team and updated every session - overwrite, don't accumulate.
+
+## Files
+
+| File                         | Owner | Purpose                                                 |
+| ---------------------------- | ----- | ------------------------------------------------------- |
+| [DEV.md](./DEV.md)           | Dev   | Development team handoff - read at SOD, update at EOD   |
+| [PM.md](./PM.md)             | PM    | Product team handoff - context, decisions, next steps   |
+| [QA.md](./QA.md)             | PM    | QA session focus - prepared by PM, delivered by Captain |
+| [TEMPLATE.md](./TEMPLATE.md) | -     | Handoff file template                                   |
+| [README.md](./README.md)     | -     | Handoff system documentation and rules                  |

--- a/docs/pm/index.md
+++ b/docs/pm/index.md
@@ -1,0 +1,21 @@
+---
+title: Product Management
+sidebar:
+  order: 0
+---
+
+Product requirements and research for the Durgan Field Guide (DFG) venture.
+Includes the synthesized PRD and the multi-round, multi-role contributions that
+produced it.
+
+## Files
+
+| File               | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| [prd.md](./prd.md) | Synthesized Product Requirements Document (3-round, 6-role review) |
+
+## Directories
+
+| Directory                                  | Description                                           |
+| ------------------------------------------ | ----------------------------------------------------- |
+| [prd-contributions/](./prd-contributions/) | Raw per-role contributions from each PRD review round |

--- a/docs/pm/prd-contributions/index.md
+++ b/docs/pm/prd-contributions/index.md
@@ -1,0 +1,22 @@
+---
+title: PRD Contributions
+sidebar:
+  order: 0
+---
+
+Per-role contributions from the multi-round PRD review process. Each round
+built on the previous, with six roles providing distinct perspectives on the
+product requirements.
+
+## Rounds
+
+| Directory              | Description                                                           |
+| ---------------------- | --------------------------------------------------------------------- |
+| [round-1/](./round-1/) | Initial contributions - first-pass perspectives from each role        |
+| [round-2/](./round-2/) | Second round - refined after reviewing round-1 inputs                 |
+| [round-3/](./round-3/) | Final round - converged requirements feeding into the synthesized PRD |
+
+## Roles
+
+Each round contains contributions from: business-analyst, competitor-analyst,
+product-manager, target-customer, technical-lead, ux-lead.

--- a/docs/pm/prd-contributions/round-1/index.md
+++ b/docs/pm/prd-contributions/round-1/index.md
@@ -1,0 +1,19 @@
+---
+title: PRD Contributions - Round 1
+sidebar:
+  order: 0
+---
+
+First-round PRD contributions from each role. These represent initial
+perspectives before cross-role review and synthesis.
+
+## Files
+
+| File                                             | Role               |
+| ------------------------------------------------ | ------------------ |
+| [business-analyst.md](./business-analyst.md)     | Business Analyst   |
+| [competitor-analyst.md](./competitor-analyst.md) | Competitor Analyst |
+| [product-manager.md](./product-manager.md)       | Product Manager    |
+| [target-customer.md](./target-customer.md)       | Target Customer    |
+| [technical-lead.md](./technical-lead.md)         | Technical Lead     |
+| [ux-lead.md](./ux-lead.md)                       | UX Lead            |

--- a/docs/pm/prd-contributions/round-2/index.md
+++ b/docs/pm/prd-contributions/round-2/index.md
@@ -1,0 +1,19 @@
+---
+title: PRD Contributions - Round 2
+sidebar:
+  order: 0
+---
+
+Second-round PRD contributions from each role. These reflect refinements after
+reviewing and reacting to round-1 inputs across all roles.
+
+## Files
+
+| File                                             | Role               |
+| ------------------------------------------------ | ------------------ |
+| [business-analyst.md](./business-analyst.md)     | Business Analyst   |
+| [competitor-analyst.md](./competitor-analyst.md) | Competitor Analyst |
+| [product-manager.md](./product-manager.md)       | Product Manager    |
+| [target-customer.md](./target-customer.md)       | Target Customer    |
+| [technical-lead.md](./technical-lead.md)         | Technical Lead     |
+| [ux-lead.md](./ux-lead.md)                       | UX Lead            |

--- a/docs/pm/prd-contributions/round-3/index.md
+++ b/docs/pm/prd-contributions/round-3/index.md
@@ -1,0 +1,19 @@
+---
+title: PRD Contributions - Round 3
+sidebar:
+  order: 0
+---
+
+Final-round PRD contributions from each role. These converged inputs were
+synthesized into the canonical PRD at `docs/pm/prd.md`.
+
+## Files
+
+| File                                             | Role               |
+| ------------------------------------------------ | ------------------ |
+| [business-analyst.md](./business-analyst.md)     | Business Analyst   |
+| [competitor-analyst.md](./competitor-analyst.md) | Competitor Analyst |
+| [product-manager.md](./product-manager.md)       | Product Manager    |
+| [target-customer.md](./target-customer.md)       | Target Customer    |
+| [technical-lead.md](./technical-lead.md)         | Technical Lead     |
+| [ux-lead.md](./ux-lead.md)                       | UX Lead            |

--- a/docs/process/index.md
+++ b/docs/process/index.md
@@ -1,0 +1,14 @@
+---
+title: Process
+sidebar:
+  order: 0
+---
+
+Project instructions, workflows, and reference documentation for the Durgan
+Field Guide venture.
+
+## Files
+
+| File                                                       | Description                                                                           |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [dfg-project-description.md](./dfg-project-description.md) | Full project description - architecture, conventions, deployment, and quick reference |


### PR DESCRIPTION
Adds missing index.md files and README per the docs-standard.md framework in crane-console.

## Changes

- `docs/README.md` - new top-level directory index
- `docs/handoffs/index.md` - index for handoff files
- `docs/pm/index.md` - index for product management docs
- `docs/pm/prd-contributions/index.md` - index for PRD contribution rounds
- `docs/pm/prd-contributions/round-1/index.md` - round 1 file listing
- `docs/pm/prd-contributions/round-2/index.md` - round 2 file listing
- `docs/pm/prd-contributions/round-3/index.md` - round 3 file listing
- `docs/process/index.md` - index for process/workflow docs

Notes the non-canonical placement of `worktrees-analysis.md` at the docs root in the README; file left in place.