### PR TITLE
feat: migrate @venturecrane/* harness to GitHub Packages registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm install
 
       - name: Type check
@@ -93,8 +97,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm install
 
       - name: Type check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,9 +20,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Run audit

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,9 +18,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Typecheck

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@venturecrane:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,9 @@ workers/dfg-scout/*.html
 **/public/sw.js
 **/public/sw.js.map
 **/public/swe-worker-*.js
+
+# Local/agent/tool artifacts that may sit in the working tree but are
+# not part of the source. .gitignore excludes them from commits; this
+# stops format:check from tripping on them locally too.
+**/.vercel/
+**/.claude/settings.local.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2952,8 +2952,8 @@
     },
     "node_modules/@venturecrane/crane-test-harness": {
       "version": "0.1.0",
-      "resolved": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
-      "integrity": "sha512-TZNAZPD5n8UUcWYlIKjLulV7KKQDuyflZmsPIgTxI5PBvXPH0cguEbXnxIhxs/546/0vEXBRheLa5A+h5DcMRg==",
+      "resolved": "https://npm.pkg.github.com/download/@venturecrane/crane-test-harness/0.1.0/768d12bf8583340607a9d60ab8a8824baa067326",
+      "integrity": "sha512-6zxAPaltQuC+SQp3cu5bvrzlTo8P/vPWuDwSV+KCWrpAbjPPKR/k2heGWwgWSFP6intAtta5qgWkZ4CEYtwtvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10856,7 +10856,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241218.0",
-        "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+        "@venturecrane/crane-test-harness": "^0.1.0",
         "typescript": "^5.7.2",
         "vitest": "^4.0.18",
         "wrangler": "^4.69.0"
@@ -11553,7 +11553,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251209.0",
-        "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+        "@venturecrane/crane-test-harness": "^0.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.16",
         "wrangler": "^4.69.0"

--- a/workers/dfg-api/package.json
+++ b/workers/dfg-api/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241218.0",
-    "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+    "@venturecrane/crane-test-harness": "^0.1.0",
     "typescript": "^5.7.2",
     "vitest": "^4.0.18",
     "wrangler": "^4.69.0"

--- a/workers/dfg-scout/package.json
+++ b/workers/dfg-scout/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20251209.0",
-		"@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+		"@venturecrane/crane-test-harness": "^0.1.0",
 		"typescript": "^5.9.3",
 		"vitest": "^4.0.16",
 		"wrangler": "^4.69.0"


### PR DESCRIPTION
## Summary

- Swap `@venturecrane/crane-test-harness` from pinned GitHub Releases tarball URL to `^0.1.0` semver dep resolved from the GitHub Packages npm registry, in both `workers/dfg-api` and `workers/dfg-scout`.
- Add `.npmrc` at repo root for the `@venturecrane` scope + `NODE_AUTH_TOKEN` auth pattern.
- Update `verify.yml`, `security.yml`, and the two `ci.yml` jobs that install harness to declare the registry and pass `NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}` on install. dfg-app job is untouched (does not consume @venturecrane/* packages).
- Regenerate `package-lock.json` so the resolved URL points at `npm.pkg.github.com`.
- `.prettierignore`: exclude `.vercel/` and `.claude/settings.local.json` so local/tool artifacts don't fail `format:check` (pre-existing drift, surfaced by this branch).

## Context

Companion migration to venturecrane/crane-console#579 (merged). The foundation PR added `NODE_AUTH_TOKEN` to `config/ventures.json` `sharedSecrets.keys`, so Infisical `/vc` + the `crane` launcher carry the token into every venture's agent shell for local `npm install`. CI uses the Actions-provided `GITHUB_TOKEN` with `packages: read` inherited from the default permissions.

dfg-console was one of 4 ventures that adopted the harness via tarball URLs the morning after ss-console introduced the registry pattern; this brings dfg-console onto the uniform shape.

## Test plan

- [x] `npm install` locally resolves from `npm.pkg.github.com/download/@venturecrane/crane-test-harness/0.1.0/...` (verified via `package-lock.json` diff).
- [x] `npm run format:check` passes locally.
- [ ] CI Verify + Security + CI (dfg-app, dfg-scout, dfg-api) workflows pass on this branch — first registry-authenticated install in dfg-console CI.

## Related

- crane-console PR #579 — foundation (merged: ff6d5f5)
- sc-console PR #105 (migration companion)
- ke-console / dc-console equivalents follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)