### PR TITLE
fix(auth): graceful no-op when Clerk env vars unset

### DIFF
--- a/apps/dfg-app/src/app/layout.tsx
+++ b/apps/dfg-app/src/app/layout.tsx
@@ -35,18 +35,24 @@ export const viewport: Viewport = {
   viewportFit: 'cover',
 }
 
+const CLERK_CONFIGURED = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <ClerkProvider>
-      <html lang="en" className="overflow-x-hidden">
-        <body className={`${inter.className} overflow-x-hidden w-full max-w-[100vw]`}>
-          <Providers>
-            <div className="min-h-screen bg-gray-50 dark:bg-gray-900 w-full max-w-[100vw] overflow-x-hidden">
-              {children}
-            </div>
-          </Providers>
-        </body>
-      </html>
-    </ClerkProvider>
+  const body = (
+    <html lang="en" className="overflow-x-hidden">
+      <body className={`${inter.className} overflow-x-hidden w-full max-w-[100vw]`}>
+        <Providers>
+          <div className="min-h-screen bg-gray-50 dark:bg-gray-900 w-full max-w-[100vw] overflow-x-hidden">
+            {children}
+          </div>
+        </Providers>
+      </body>
+    </html>
   )
+
+  // ClerkProvider throws on init when publishableKey is missing. Skip it
+  // (and the gated console behind it) until Captain provisions Clerk per
+  // docs/runbooks/waitlist-launch.md. The public marketing landing at /
+  // renders either way.
+  return CLERK_CONFIGURED ? <ClerkProvider>{body}</ClerkProvider> : body
 }

--- a/apps/dfg-app/src/middleware.ts
+++ b/apps/dfg-app/src/middleware.ts
@@ -9,14 +9,24 @@
  * Everything else is protected via Clerk allowlist (Restricted Mode +
  * magic link configured in the Clerk dashboard). Unauth visitors are
  * redirected to /sign-in.
+ *
+ * If Clerk env vars are not configured (e.g. before Captain's manual
+ * provisioning per docs/runbooks/waitlist-launch.md), the middleware
+ * passes all requests through. This lets the public marketing landing
+ * render even before Clerk is set up; gated routes are reachable
+ * unauthenticated until Clerk is provisioned.
  */
 
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
-import { NextResponse } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
+
+const CLERK_CONFIGURED = Boolean(
+  process.env.CLERK_SECRET_KEY && process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+)
 
 const isPublicRoute = createRouteMatcher(['/', '/sign-in(.*)', '/sign-up(.*)', '/api/waitlist'])
 
-export default clerkMiddleware(async (auth, req) => {
+const guardedMiddleware = clerkMiddleware(async (auth, req) => {
   if (isPublicRoute(req)) return
 
   const { userId } = await auth()
@@ -24,6 +34,10 @@ export default clerkMiddleware(async (auth, req) => {
 
   return NextResponse.redirect(new URL('/sign-in', req.url))
 })
+
+const passThroughMiddleware = (_req: NextRequest) => NextResponse.next()
+
+export default CLERK_CONFIGURED ? guardedMiddleware : passThroughMiddleware
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary

After #293 merged, dfg-console production returns 500 (\`MIDDLEWARE_INVOCATION_FAILED\`) because Clerk env vars are not yet provisioned in Vercel.

Both \`middleware.ts\` and \`<ClerkProvider>\` throw on init when those vars are missing. This change makes both conditional on env presence:

- **middleware.ts**: pass-through (\`NextResponse.next()\`) when Clerk is unconfigured. Gated routes reachable without auth until provisioning — acceptable for a single-operator tool whose apex is not yet linked to a real domain.
- **app/layout.tsx**: skip \`<ClerkProvider>\` wrapper when \`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY\` is unset.

Once Captain follows the runbook and sets Clerk env vars in Vercel, the next deploy automatically restores the gated behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)