### PR TITLE
chore(marketing): hide sign-in CTA during private alpha

### DIFF
--- a/apps/dfg-app/src/components/marketing/Footer.tsx
+++ b/apps/dfg-app/src/components/marketing/Footer.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-
 export function Footer() {
   const year = new Date().getFullYear()
   return (
@@ -20,12 +18,6 @@ export function Footer() {
           >
             Join the list
           </a>
-          <Link
-            href="/sign-in"
-            className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
-          >
-            Sign in
-          </Link>
         </nav>
       </div>
     </footer>

--- a/apps/dfg-app/src/components/marketing/Nav.tsx
+++ b/apps/dfg-app/src/components/marketing/Nav.tsx
@@ -1,5 +1,8 @@
 import Link from 'next/link'
 
+// Sign-in CTA is intentionally hidden during private alpha. The /sign-in
+// route still exists; just unlinked from the public marketing surface.
+// Re-add when public beta opens.
 export function Nav() {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-gray-50/90 dark:bg-gray-900/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
@@ -12,20 +15,12 @@ export function Nav() {
             Durgan Field Guide
           </span>
         </Link>
-        <div className="flex items-center gap-5">
-          <a
-            href="#waitlist"
-            className="hidden sm:inline text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
-          >
-            Join the list
-          </a>
-          <Link
-            href="/sign-in"
-            className="text-sm font-medium text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
-          >
-            Sign in
-          </Link>
-        </div>
+        <a
+          href="#waitlist"
+          className="text-sm font-medium text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+        >
+          Join the list
+        </a>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary

Removes the "Sign in" CTA from the public marketing surface during private alpha. The `/sign-in` route stays live and reachable by direct URL — just unlinked so casual visitors do not see an auth gate they cannot get past.

When public beta opens, restore the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)