### PR TITLE
chore(workers): pause production cron triggers (#299)

### DIFF
--- a/workers/dfg-api/wrangler.toml
+++ b/workers/dfg-api/wrangler.toml
@@ -28,8 +28,10 @@ database_id = "e6af9d25-b031-4958-a3b2-455bafdff5f1"
 [env.production]
 name = "dfg-api"
 
-[env.production.triggers]
-crons = ["*/5 * * * *"]  # Check watch triggers every 5 minutes
+# Cron paused 2026-04-27 — venture in cold storage. See issue #299.
+# Re-enable when active dev resumes by restoring the triggers block:
+# [env.production.triggers]
+# crons = ["*/5 * * * *"]  # Check watch triggers every 5 minutes
 
 [env.production.vars]
 ENVIRONMENT = "production"

--- a/workers/dfg-scout/wrangler.toml
+++ b/workers/dfg-scout/wrangler.toml
@@ -40,8 +40,10 @@ bucket_name = "dfg-evidence"
 [env.production]
 name = "dfg-scout"
 
-[env.production.triggers]
-crons = ["*/15 * * * *"]
+# Cron paused 2026-04-27 — venture in cold storage. See issue #299.
+# Re-enable when active dev resumes by restoring the triggers block:
+# [env.production.triggers]
+# crons = ["*/15 * * * *"]
 
 [env.production.vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Summary

DFG is in cold storage while we focus on other ventures. This PR pauses the two production cron triggers that drive ongoing compute and Anthropic API spend with no active operator using the output.

- `dfg-scout` `*/15 * * * *` — scrapes auction sites → service-binds into `dfg-analyst` (Claude API spend)
- `dfg-api` `*/5 * * * *` — checks watch triggers (no users → no-op invocations)

Workers stay deployed; HTTP routes (waitlist, health, public API surface) remain reachable.

## After merge

**This repo has no CI auto-deploy** — the merge alone does not pause anything in prod. Manual deploy required:

```bash
cd workers/dfg-scout && npx wrangler deploy --env production
cd workers/dfg-api && npx wrangler deploy --env production
```

Then verify: CF dashboard → Workers → each worker → Settings → Triggers → "Cron Triggers" should be empty.

## Re-enable

When DFG dev resumes, restore the commented `[env.production.triggers]` blocks and redeploy. `dfg-analyst` needs no change — it has no cron of its own.

## Test plan

- [ ] CI green (lint / typecheck / tests)
- [ ] After merge: `wrangler deploy --env production` from each worker dir
- [ ] CF dashboard confirms cron triggers gone on both workers
- [ ] `/health` endpoints still respond
- [ ] Waitlist signup still works (validate from marketing site)

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)