### PR TITLE
fix(scout): remove dead SCOUT_KV binding

### DIFF
--- a/workers/dfg-scout/src/core/env.ts
+++ b/workers/dfg-scout/src/core/env.ts
@@ -6,7 +6,6 @@ export interface Env {
 	// Databases
 	DFG_DB: D1Database;
 	DFG_EVIDENCE: R2Bucket;
-	SCOUT_KV: KVNamespace;
 
 	// Security
 	RESET_TOKEN: string;

--- a/workers/dfg-scout/wrangler.toml
+++ b/workers/dfg-scout/wrangler.toml
@@ -21,10 +21,6 @@ STEAL_THRESHOLD = "2000"
 ANALYST_URL = "http://localhost:8788"
 R2_PUBLIC_URL = "https://pub-dfg-evidence.r2.dev"
 
-[[kv_namespaces]]
-binding = "SCOUT_KV"
-id = "654357f4ea634d8db682f54bae0170a2"
-
 [[d1_databases]]
 binding = "DFG_DB"
 database_name = "dfg-scout-db-preview"
@@ -51,10 +47,6 @@ MAX_BID_LIMIT = "6000"
 STEAL_THRESHOLD = "2000"
 ANALYST_URL = "https://dfg-analyst.automation-ab6.workers.dev"
 R2_PUBLIC_URL = "https://pub-dfg-evidence.r2.dev"
-
-[[env.production.kv_namespaces]]
-binding = "SCOUT_KV"
-id = "fdd4f609a8d34b32817d6f156396898a"
 
 [[env.production.d1_databases]]
 binding = "DFG_DB"


### PR DESCRIPTION
## Summary

Both KV namespaces referenced by `dfg-scout` no longer exist in the Cloudflare account:

- prod \`SCOUT_KV\` (\`fdd4f609a8d34b32817d6f156396898a\`) — `code 10013: namespace not found`
- dev \`SCOUT_KV\` (\`654357f4ea634d8db682f54bae0170a2\`) — `code 10013: namespace not found`

The \`SCOUT_KV: KVNamespace\` field was declared in the `Env` type but **never consumed by any worker source**. Pure orphan binding (likely from an early design that didn't ship). Confirmed via repo-wide grep: only references are the type declaration + the two \`wrangler.toml\` blocks being removed here.

## Why this matters

`wrangler deploy` validates all bindings before deploying. The dead KV references caused deploys to fail with `code 10041: KV namespace not found`. Removing the binding unblocks future deploys without recreating an unused namespace.

## Runtime impact

None. The deployed dfg-scout worker still has the dead binding until next deploy, but the production cron is paused (#299) so the worker isn't running scheduled work.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 31 tests pass (3 files)
- [ ] CI passes (lint / typecheck / tests)

## Discovered (out of scope, separate issue)

The dev D1 database `dfg-scout-db-preview` (`e6af9d25-b031-4958-a3b2-455bafdff5f1`) is also missing — referenced by both `dfg-scout` and `dfg-api` wrangler.toml dev blocks. Will file as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)