### PR TITLE
fix(dfg-api): scope db:migrate to local, document prod path

### DIFF
--- a/docs/runbooks/d1-migrations.md
+++ b/docs/runbooks/d1-migrations.md
@@ -1,0 +1,101 @@
+# D1 Migrations Runbook
+
+How to run schema migrations against DFG's D1 databases.
+
+## Background
+
+DFG has one shared D1 database with two environments:
+
+| Env        | Binding name (wrangler.toml) | Database name          | UUID                                                  |
+| ---------- | ---------------------------- | ---------------------- | ----------------------------------------------------- |
+| Local dev  | `DB` (default block)         | `dfg-scout-db-preview` | local SQLite via miniflare; remote UUID may not exist |
+| Production | `DB` (env.production block)  | `dfg-scout-db`         | `08c267b8-b252-422a-8381-891d12917b33`                |
+
+Both `dfg-scout` and `dfg-api` workers bind to this database. Each worker keeps its own `migrations/` directory:
+
+- `workers/dfg-scout/migrations/` — scout uses a consolidated `schema.sql` for fresh DBs (the numbered `001-...008-` files are historical and conflict with `schema.sql`; the test harness in `workers/dfg-scout/test/harness/migrations.test.ts` enforces this).
+- `workers/dfg-api/migrations/` — eight files `0001_*.sql` through `0008_*.sql`, applied sequentially via `wrangler d1 migrations apply`.
+
+## Local dev
+
+```bash
+cd workers/dfg-api
+npm run db:migrate:local   # → wrangler d1 migrations apply dfg-scout-db-preview --local
+```
+
+Idempotent. Wrangler auto-discovers `migrations/` and tracks applied migrations in a `d1_migrations` table inside the local SQLite store.
+
+For scout's local schema (separate concern):
+
+```bash
+cd workers/dfg-scout
+npx wrangler d1 execute dfg-scout-db-preview --file=migrations/schema.sql --local
+```
+
+## Production migrations
+
+**Production is intentionally NOT wired up to the migrations runner.** `npm run db:migrate` is a deliberate no-op that points readers here. Reason: the existing prod D1 (`dfg-scout-db`, 18 tables, ~22 MB) was bootstrapped by hand or via the legacy `wrangler d1 execute --file=...` approach. It does **not** have a `d1_migrations` tracking table, so `wrangler d1 migrations apply --remote` would treat all 8 migrations as unapplied and try to `CREATE TABLE` tables that already exist — failing partway through.
+
+If you need to enable the runner for prod (one-time prep, gated on Captain approval):
+
+1. Verify with `wrangler d1 execute dfg-scout-db --remote --command="SELECT name FROM sqlite_master WHERE type='table'"` that all 8 migrations' tables already exist.
+2. Seed `d1_migrations` to mark all current migrations as applied:
+   ```sql
+   CREATE TABLE IF NOT EXISTS d1_migrations (
+     id INTEGER PRIMARY KEY AUTOINCREMENT,
+     name TEXT UNIQUE,
+     applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+   );
+   INSERT INTO d1_migrations (name, applied_at) VALUES
+     ('0001_opportunities.sql', CURRENT_TIMESTAMP),
+     ('0002_drop_alert_dismissals.sql', CURRENT_TIMESTAMP),
+     ('0003_analysis_runs.sql', CURRENT_TIMESTAMP),
+     ('0004_staleness_columns.sql', CURRENT_TIMESTAMP),
+     ('0005_standardize_sierra_source.sql', CURRENT_TIMESTAMP),
+     ('0006_mvc_events.sql', CURRENT_TIMESTAMP),
+     ('0007_add_ai_analysis_json.sql', CURRENT_TIMESTAMP),
+     ('0008_create_waitlist_signups.sql', CURRENT_TIMESTAMP);
+   ```
+3. Update `workers/dfg-api/package.json` `db:migrate` to:
+   ```json
+   "db:migrate": "wrangler d1 migrations apply dfg-scout-db --remote"
+   ```
+4. Run `wrangler d1 migrations list dfg-scout-db --remote` and confirm 0 pending migrations.
+
+After that step, future migrations can be added as `0009_*.sql` etc. and applied via `npm run db:migrate`.
+
+## Recreating the dev preview D1
+
+If `dfg-scout-db-preview` doesn't exist remotely (it was deleted and needs recreation — see issue #302):
+
+```bash
+# 1. Create the DB
+cd workers/dfg-scout
+npx wrangler d1 create dfg-scout-db-preview --location=wnam
+# Capture the new UUID from output
+
+# 2. Apply scout's consolidated schema (NOT migrations apply)
+npx wrangler d1 execute dfg-scout-db-preview --file=migrations/schema.sql --remote
+
+# 3. Apply api's migrations via the runner
+cd ../dfg-api
+npx wrangler d1 migrations apply dfg-scout-db-preview --remote
+
+# 4. Verify table count matches prod
+npx wrangler d1 execute dfg-scout-db-preview --remote \
+  --command='SELECT COUNT(*) AS table_count FROM sqlite_master WHERE type="table"'
+# Expect ~18 tables.
+
+# 5. Update both wrangler.toml files (dfg-scout, dfg-api) with the new UUID
+#    in their default top-level [[d1_databases]] blocks. PR the change.
+```
+
+If any step fails: `npx wrangler d1 delete dfg-scout-db-preview --skip-confirmation` and start over. **Do not partially edit wrangler.toml.**
+
+## Why the asymmetry
+
+Scout's `schema.sql` was authored as a consolidated current-state schema; the numbered files (001-008) are historical migrations that pre-date schema.sql. Applying both to a fresh DB causes "duplicate column" errors. The harness validates schema.sql alone is correct.
+
+dfg-api was authored migration-first with no consolidated schema, so its directory is purely sequential numbered files.
+
+Unifying both workers onto a single pattern is dev-session work, not dev-readiness work.

--- a/workers/dfg-api/package.json
+++ b/workers/dfg-api/package.json
@@ -8,8 +8,8 @@
     "deploy:production": "wrangler deploy --env production",
     "tail": "wrangler tail",
     "tail:production": "wrangler tail --env production",
-    "db:migrate": "wrangler d1 execute dfg-scout-db --remote --file=migrations/001-opportunities.sql",
-    "db:migrate:local": "wrangler d1 execute dfg-scout-db --local --file=migrations/001-opportunities.sql",
+    "db:migrate": "echo 'Prod migrations require seeding the d1_migrations tracking table first. See docs/runbooks/d1-migrations.md.' && exit 1",
+    "db:migrate:local": "wrangler d1 migrations apply dfg-scout-db-preview --local",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --project unit --project harness",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

Second of three PRs (PR-B) clearing infra debt before DFG dev resumes.

The dfg-api `db:migrate` and `db:migrate:local` npm scripts pointed at \`migrations/001-opportunities.sql\`, but the actual file is \`0001_opportunities.sql\`. Both scripts have been silently broken.

**Local path**: switched to the canonical wrangler runner (\`wrangler d1 migrations apply --local\`). Idempotent. Verified locally — applies all 8 migrations on fresh DB; re-running reports "No migrations to apply!".

**Prod path**: deliberate no-op pointing at the new runbook. Reason: existing prod D1 (18 tables, ~22 MB) was bootstrapped by hand or via legacy \`--file=\` invocations, so it has no \`d1_migrations\` tracking table. Running the runner against prod would treat all migrations as unapplied and fail trying to \`CREATE TABLE\` existing tables. Runbook documents the one-time seed required to enable the runner for prod, gated on Captain approval.

## Files

- \`workers/dfg-api/package.json\` — \`db:migrate:local\` switched to runner; \`db:migrate\` becomes \`echo … && exit 1\` pointing at the runbook.
- \`docs/runbooks/d1-migrations.md\` — new. Documents local + prod paths, dev-DB recreation procedure (#302), and the schema.sql-vs-numbered asymmetry between dfg-scout and dfg-api.

**No wrangler.toml edit needed**: wrangler 4.x auto-discovers \`migrations/\` adjacent to \`wrangler.toml\`. The \`[[migrations]]\` block referenced in the original plan turned out to be unnecessary — verified by `wrangler d1 migrations list` working without it.

## Test plan

- [x] \`npm run db:migrate:local\` — applies all 8 migrations to fresh local DB
- [x] \`npm run db:migrate:local\` (re-run) — exits 0, "No migrations to apply!"
- [x] \`npm run db:migrate\` — exits 1 with runbook pointer
- [x] \`cd workers/dfg-api && npm test\` — 41 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)