### PR TITLE
chore(workers): update dev D1 UUID after recreation (closes #302)

### DIFF
--- a/workers/dfg-api/wrangler.toml
+++ b/workers/dfg-api/wrangler.toml
@@ -20,7 +20,7 @@ ENVIRONMENT = "development"
 [[d1_databases]]
 binding = "DB"
 database_name = "dfg-scout-db-preview"
-database_id = "e6af9d25-b031-4958-a3b2-455bafdff5f1"
+database_id = "1f1376c2-1ca0-4284-b122-1f6c2ecd58be"
 
 # =============================================================================
 # PRODUCTION

--- a/workers/dfg-scout/wrangler.toml
+++ b/workers/dfg-scout/wrangler.toml
@@ -24,7 +24,7 @@ R2_PUBLIC_URL = "https://pub-dfg-evidence.r2.dev"
 [[d1_databases]]
 binding = "DFG_DB"
 database_name = "dfg-scout-db-preview"
-database_id = "e6af9d25-b031-4958-a3b2-455bafdff5f1"
+database_id = "1f1376c2-1ca0-4284-b122-1f6c2ecd58be"
 
 [[r2_buckets]]
 binding = "DFG_EVIDENCE"


### PR DESCRIPTION
## Summary

Final piece of the dev-readiness pass (PR-D). Closes #302.

The dev preview D1 \`dfg-scout-db-preview\` (UUID \`e6af9d25-...\`) had been deleted from the Cloudflare account at some point. Recreated the database in WNAM region; new UUID is \`1f1376c2-1ca0-4284-b122-1f6c2ecd58be\`. This PR updates both \`workers/dfg-scout/wrangler.toml\` and \`workers/dfg-api/wrangler.toml\` dev \`[[d1_databases]]\` blocks to point at the new UUID.

## Bootstrap (already executed)

- \`workers/dfg-scout/migrations/schema.sql\` — consolidated scout schema (per the \`migrations.test.ts\` harness contract: NOT the numbered files, which conflict with schema.sql).
- \`workers/dfg-api/migrations/0001_*.sql\` through \`0008_*.sql\` — applied sequentially via \`wrangler d1 migrations apply\` (the runner enabled in #304).
- One-off CREATE for \`source_category_map\` (structural only, no seed inserts) to match the table prod has via scout migration 002.

## Verification

```
$ wrangler d1 execute dfg-scout-db-preview --remote --command='SELECT COUNT(*) FROM sqlite_master WHERE type="table" AND name NOT LIKE "_cf_%" AND name NOT LIKE "sqlite_%"'
→ 16 tables
```

Tables in new dev DB:
\`analyses\`, \`analysis_runs\`, \`category_defs\`, \`d1_migrations\`, \`failed_operations\`, \`listings\`, \`mvc_events\`, \`operator_actions\`, \`opportunities\`, \`outcomes\`, \`price_guides\`, \`scout_runs\`, \`source_category_map\`, \`sources\`, \`tuning_events\`, \`waitlist_signups\`.

Matches prod for all 16 live tables. Two prod-only tables (\`categories\`, \`operator_config\`) are not in dev — they're orphans in prod (no worker source references them). Filing a follow-up issue documenting that prod schema drift.

## Production untouched

Production D1 (\`dfg-scout-db\`, UUID \`08c267b8-...\`) was not modified. \`[env.production.d1_databases]\` blocks in both wrangler.toml files unchanged.

## Test plan

- [x] New D1 created and bootstrapped (16 tables)
- [x] \`wrangler d1 migrations list dfg-scout-db-preview --local\` works against the new ID
- [x] Production D1 untouched (verified COUNT still 18 there)
- [ ] CI green
- [ ] After merge: \`cd workers/dfg-api && npm run db:migrate:local\` continues to work locally

Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)