### PR TITLE
chore(dfg-analyst): drop @dfg/money-math vitest alias now unnecessary

### DIFF
--- a/workers/dfg-analyst/vitest.config.ts
+++ b/workers/dfg-analyst/vitest.config.ts
@@ -1,18 +1,9 @@
 import { defineConfig } from 'vitest/config'
-import { resolve } from 'node:path'
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
-  },
-  resolve: {
-    alias: {
-      // The workspace package ships its compiled dist via `tsup`, but no
-      // `prepare` script builds it on install. Resolve the source directly
-      // so tests don't depend on a prior `npm run build` in the package.
-      '@dfg/money-math': resolve(__dirname, '../../packages/dfg-money-math/src/index.ts'),
-    },
   },
 })


### PR DESCRIPTION
## Summary

Cleanup follow-up to #320 + #321. Removes the `resolve.alias` workaround and the `node:path` import from `workers/dfg-analyst/vitest.config.ts`.

### Why this is now safe

PR #320 added the alias as a workaround because `@dfg/money-math` ships compiled `dist/` via tsup but, at the time, had no `prepare` script — so a fresh checkout left `dist/` empty and vitest's strict `exports`-aware resolver couldn't find the package.

PR #321 added `"prepare": "npm run build"` to `packages/dfg-money-math/package.json` (mirroring the `packages/dfg-types/package.json` pattern). Now `npm install` auto-populates the dist on every fresh checkout, and vitest resolves the package via its normal `exports` map without needing the alias.

### Diff

`-9 / +0` in one file. Drops the `import { resolve } from 'node:path'` and the entire `resolve.alias` block.

## Test plan

- [x] Removed `workers/dfg-analyst/node_modules/` and `packages/dfg-money-math/dist/`, ran `npm install` from repo root — `dist/` repopulates via the prepare script (#321).
- [x] `npm test` in `workers/dfg-analyst/` passes all 18 tests with the alias removed.
- [x] `npm run verify` from repo root passes (typecheck + format:check + lint + test across all 7 workspaces).
- [ ] CI green.

No issue closes; this is hygiene.