### PR TITLE
fix(sync-docs): match current venturecrane org in upload-doc script

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -97,18 +97,30 @@ else
     # Venture-specific: determine from repo
     if [ -n "$GITHUB_REPOSITORY" ]; then
       case "$GITHUB_REPOSITORY" in
-        *venturecrane/crane-console*)
+        *venturecrane/crane-console*|*crane-console*)
           SCOPE="vc"
           ;;
-        *siliconcrane/sc-console*)
+        *venturecrane/sc-console*|*sc-console*)
           SCOPE="sc"
           ;;
-        *durganfieldguide/dfg-console*)
+        *venturecrane/dfg-console*|*dfg-console*)
           SCOPE="dfg"
+          ;;
+        *venturecrane/ke-console*|*ke-console*)
+          SCOPE="ke"
+          ;;
+        *venturecrane/smd-console*|*smd-console*)
+          SCOPE="smd"
+          ;;
+        *venturecrane/dc-console*|*dc-console*)
+          SCOPE="dc"
+          ;;
+        *venturecrane/ss-console*|*ss-console*)
+          SCOPE="ss"
           ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console"
+          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc,ss}-console"
           exit 1
           ;;
       esac


### PR DESCRIPTION
## Summary

Fixes the recurring \`Sync Docs to Context Worker\` / \`Upload Documentation\` failure (15d old in the notification feed). The script's case statement was matching against obsolete org paths (\`durganfieldguide/dfg-console\`, \`siliconcrane/sc-console\`, \`venturecrane/crane-console\` only). Every venture repo is under \`venturecrane/\` today, so when the workflow ran on main it fell through to the error branch with \"Cannot determine venture from repo: venturecrane/dfg-console\" and exited 1.

Updated patterns to cover all current ventures (vc, sc, dfg, ke, smd, dc, ss), mirroring the working version in \`crane-console/scripts/upload-doc-to-context-worker.sh\`.

## Verification

\`\`\`
GITHUB_REPOSITORY=\"venturecrane/dfg-console\" → SCOPE=dfg ✓
\`\`\`

Same bug exists in 3 sibling repos with their own copies of this script — separate PRs incoming for ke-console, dc-console, sc-console.

## Test plan

- [ ] CI passes
- [ ] After merge, next change to \`docs/process/**/*.md\` triggers a green Sync Docs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)