### PR TITLE
feat(ci): adopt canonical AC-tick workflow callers (#775 cascade)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,33 @@
 
 - [ ]
 
+## Acceptance criteria status
+
+<!--
+For each acceptance criterion in the linked issue, state which commit/file
+satisfies it OR mark it deferred with `scope-deferred` label + rationale below.
+
+Do not skip ACs you didn't touch — list them all and mark them as already-met,
+N/A, or deferred. Reviewers approve based on this table. Auto-ticked on merge
+by .github/workflows/tick-acs-on-merge.yml — see
+https://github.com/venturecrane/crane-console/blob/main/docs/runbooks/ac-tick-workflow-rollout.md
+-->
+
+| AC (verbatim from issue) | Status               | Evidence                         |
+| ------------------------ | -------------------- | -------------------------------- |
+|                          | met / deferred / n/a | commit / file:line / explanation |
+
+## Deferred ACs (required if `scope-deferred` label is set)
+
+<!--
+Only fill this section if you are deferring one or more ACs. Each deferred AC
+needs a rationale and a follow-on issue.
+-->
+
+- **AC:** _(verbatim text)_
+  - **Why deferred:** _(scope, dependency, infra gap, etc.)_
+  - **Tracked in:** #NNN
+
 ## Security Checklist
 
 <!-- Review each item - check if addressed or N/A -->

--- a/.github/workflows/tick-acs-on-merge.yml
+++ b/.github/workflows/tick-acs-on-merge.yml
@@ -1,0 +1,17 @@
+name: Tick ACs on PR merge
+
+# Caller for the canonical reusable workflow hosted in crane-console.
+# See https://github.com/venturecrane/crane-console/blob/main/docs/runbooks/ac-tick-workflow-rollout.md
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tick:
+    uses: venturecrane/crane-console/.github/workflows/tick-acs-on-merge-reusable.yml@tick-acs-v1
+    secrets: inherit
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read

--- a/.github/workflows/unmet-ac-on-close.yml
+++ b/.github/workflows/unmet-ac-on-close.yml
@@ -1,0 +1,15 @@
+name: Unmet AC on close
+
+# Caller for the canonical reusable workflow hosted in crane-console.
+# See https://github.com/venturecrane/crane-console/blob/main/docs/runbooks/ac-tick-workflow-rollout.md
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  check:
+    uses: venturecrane/crane-console/.github/workflows/unmet-ac-on-close-reusable.yml@tick-acs-v1
+    secrets: inherit
+    permissions:
+      issues: write


### PR DESCRIPTION
## Summary

Adds AC-tick workflow callers and appends `## Acceptance criteria status` + `## Deferred ACs` sections to the existing PR template.

This is one of 8 cascade PRs for the enterprise AC-tick rollout. Tracking issue: [crane-console#775](https://github.com/venturecrane/crane-console/issues/775).

## Linked issue

Refs venturecrane/crane-console#775 (cross-repo; closure tracked there).

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Caller workflows added | met | `.github/workflows/tick-acs-on-merge.yml` + `unmet-ac-on-close.yml` |
| PR template has `Acceptance criteria status` section | met | `.github/PULL_REQUEST_TEMPLATE.md` (this PR) |
| AC labels created | met | `force-close`, `closed-with-unmet-ac`, `scope-deferred` created via `gh label create` (out-of-band, see #775) |

## Test plan

- [ ] Workflow YAML parses (validated by GitHub on push)
- [ ] On merge: `tick-acs-on-merge` resolves no linked issue (cross-repo `Refs`) and is a no-op — confirms wiring without ticking the upstream
- [ ] First future PR with `Closes #N` to a same-repo issue exercises the matcher

## Smoke

This PR's own merge is the wiring smoke test. `tick-acs-on-merge` will see the merge, GraphQL will return no linked issues (because we use `Refs` cross-repo, not `Closes`), and the workflow logs `no linked issues — nothing to tick`. That confirms the caller resolves to the reusable. The first PR after that with `Closes #N` to a same-repo issue is the matcher's first real exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
