### PR TITLE
feat(regression): claim-origin auto-attach caller (Prong 3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression_report.md
+++ b/.github/ISSUE_TEMPLATE/regression_report.md
@@ -1,0 +1,53 @@
+---
+name: Regression Report
+about: Report a regression — something that worked before is now broken
+title: 'REGRESSION: '
+labels: 'type:bug, status:triage, regression'
+assignees: ''
+---
+
+## Problem
+
+<!-- What's broken now that worked before? Be specific. -->
+
+## When did it last work?
+
+<!-- Commit SHA / version / date / "yesterday's deploy" — anything that helps locate when the regression entered. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior (what used to happen)
+
+<!-- The pre-regression behavior. -->
+
+## Actual Behavior (what happens now)
+
+<!-- What happens instead. -->
+
+### Affected files
+
+<!--
+REQUIRED. Repo-relative file paths, one per line, bullet format.
+The regression-claim-origin workflow parses this section to look up
+prior crane_verify records for these files. Without this section, you
+will get a comment asking you to add it.
+
+Example:
+- packages/crane-mcp/src/tools/handoff.ts
+- workers/crane-context/src/endpoints/verify-ledger.ts
+- scripts/eos-gate-classify.mjs
+-->
+
+-
+
+## Evidence
+
+<!-- Screenshots, console errors, logs, API responses, stack traces. -->
+
+## Priority
+
+<!-- P0: Blocker, P1: High, P2: Medium, P3: Low -->

--- a/.github/workflows/regression-claim-origin.yml
+++ b/.github/workflows/regression-claim-origin.yml
@@ -1,0 +1,14 @@
+name: Regression Claim-Origin
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  claim-origin:
+    if: |
+      contains(github.event.issue.labels.*.name, 'regression') ||
+      github.event.label.name == 'regression'
+    uses: venturecrane/crane-console/.github/workflows/regression-claim-origin-reusable.yml@main
+    secrets:
+      CRANE_RELAY_KEY: ${{ secrets.CRANE_RELAY_KEY }}


### PR DESCRIPTION
## Summary

Wires this venture into Prong 3 of the verify-ledger system — when a `regression`-labeled issue lands here, the workflow extracts files from the body's `### Affected files` H3 (or falls back to a regex over prose for non-template issues), looks up `/verify/origin?file=…` for each path, and posts a comment listing prior `crane_verify` records.

The reusable workflow lives in `venturecrane/crane-console`; this PR is just the local caller + issue template.

## What ships

- `.github/workflows/regression-claim-origin.yml` — caller workflow, fires on `issues: [opened, labeled]` with `regression` label
- `.github/ISSUE_TEMPLATE/regression_report.md` — regression issue template that auto-applies labels (`type:bug, status:triage, regression`) and prompts for the H3 + bullet list

The `CRANE_RELAY_KEY` repo secret is set separately — confirm via `gh secret list --repo $REPO`.

## Test plan

- [ ] Open a test issue with the `regression_report` template and the H3 + bullets → workflow fires, comment lands within ~30s
- [ ] Open a test issue without the H3 but with paths in prose → fallback regex finds them
- [ ] Open an issue with no paths and the `regression` label → workflow posts the instructional comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
