### PR TITLE
docs(agents): surface coding-standards.md in AGENTS.md + CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,21 @@
 
 DFG is an operator tool and subscription SaaS for identifying undervalued physical assets and producing conservative, explainable flip guidance. It is not a marketplace and must not inflate confidence.
 
+## Coding Standards
+
+All code edits MUST follow the Venture Crane portfolio coding standard, fetched via `crane_doc('global', 'coding-standards.md')`. Key directives that apply on every change:
+
+- Parse external inputs with Zod; never `as` cast at trust boundaries.
+- No floating Promises; explicitly `await` or attach a `.catch`.
+- No module-level state in Cloudflare Workers (per-isolate state leaks across requests).
+- File/function ceilings: 500 lines/file, 75 lines/function, complexity 15, depth 4, params 5.
+- No default exports outside framework-required positions (Astro pages, Next.js App Router files, Workers entry).
+- Fetch the global doc for the full 12 directives with good/bad examples and per-stack notes.
+
+Mechanical enforcement status: dfg-console's `eslint.config.js` does NOT yet enforce the portfolio rule set; lint catches only the basic recommended rules. Self-discipline is required until the per-venture eslint adoption initiative reaches dfg-console (audit doc: `docs/research/venture-eslint-adoption-audit-2026-05-06.md` in venturecrane/crane-console). The portfolio rules are nonetheless mandatory; treat the global doc as the source of truth.
+
+These portfolio standards are PRIMARY. The DFG-specific review guidelines below (money math, staleness gating, Cloudflare hygiene, mobile patterns) are ADDITIONAL — they apply on top of the portfolio standard, not instead of it.
+
 ## Repository structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,12 +176,13 @@ This creates a session, loads documentation, and establishes handoff context. Ad
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module              | Key Rule (always applies)                                                | Fetch for details                          |
-| ------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |
-| `secrets.md`        | Verify secret VALUES, not just key existence                             | Infisical, vault, API keys, GitHub App     |
-| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                            | VCMS tags, storage rules, editorial, style |
-| `team-workflow.md`  | All changes through PRs; never push to main                              | Full workflow, escalation triggers         |
-| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh | SSH, machines, Tailscale, macOS            |
-| `pr-workflow.md`    | Push branch, `gh pr create`, never skip the PR                           | Branch naming, commit format, PR template  |
+| Module                | Key Rule (always applies)                                                                                                               | Fetch for details                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `coding-standards.md` | Parse external inputs (never cast); no floating Promises; no module-level state in Workers; 500/75/15 file/function/complexity ceilings | Portable TypeScript directives, agent-context arithmetic, per-stack notes |
+| `secrets.md`          | Verify secret VALUES, not just key existence                                                                                            | Infisical, vault, API keys, GitHub App                                    |
+| `content-policy.md`   | Never auto-save to VCMS; agents ARE the voice                                                                                           | VCMS tags, storage rules, editorial, style                                |
+| `team-workflow.md`    | All changes through PRs; never push to main                                                                                             | Full workflow, escalation triggers                                        |
+| `fleet-ops.md`        | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh                                                                | SSH, machines, Tailscale, macOS                                           |
+| `pr-workflow.md`      | Push branch, `gh pr create`, never skip the PR                                                                                          | Branch naming, commit format, PR template                                 |
 
 Fetch with: `crane_doc('global', '<module>')`


### PR DESCRIPTION
## Summary

Closes the documentation gap around the Venture Crane portfolio coding standard. dfg-console's existing AGENTS.md is a DFG-specific Codex review playbook (money math, staleness gating, mobile patterns); this PR adds a Coding Standards section that frames those DFG rules as ADDITIONAL on top of the portfolio standard, not instead of it.

dfg-console's `eslint.config.js` does not yet enforce the standard, so agent self-discipline (via doc references) is the current enforcement path. This PR adds the Coding Standards section to AGENTS.md and surfaces `coding-standards.md` in CLAUDE.md.

Companion to venturecrane/crane-console#884.

## Changes

- **AGENTS.md** - new "Coding Standards" section inserted near the top, framing DFG-specific rules as additional rather than alternative.
- **CLAUDE.md Instruction Modules row** - adds `coding-standards.md`.

## Linked issue

None - initiative-level rollout.

## Test plan

- [x] `npx prettier --check AGENTS.md CLAUDE.md` passes
- [x] `npm run lint` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)